### PR TITLE
Update OkHttp to version 3.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
          <groupId>com.squareup.okhttp3</groupId>
          <artifactId>okhttp</artifactId>
-         <version>3.10.0</version>
+         <version>3.12.0</version>
       </dependency>
       <dependency>
          <groupId>org.jctools</groupId>


### PR DESCRIPTION
One new feature that could be relevant for influx4j are the "full-operation timeouts" added in `3.12.0` (see: https://github.com/square/okhttp/blob/master/CHANGELOG.md for details).

BTW: Thank you very much for creating influx4j.