### PR TITLE
loop write buffers until showtdown is requested

### DIFF
--- a/src/main/java/com/zaxxer/influx4j/InfluxDB.java
+++ b/src/main/java/com/zaxxer/influx4j/InfluxDB.java
@@ -729,7 +729,7 @@ public class InfluxDB implements AutoCloseable {
 
                buffer.reset();
                LockSupport.parkNanos(autoFlushPeriod);
-            } while (true);
+            } while (!shutdown);
 
             buffer.clear();
             return succeeded;


### PR DESCRIPTION
if we would like to shutdown the client we are blocked until writeBuffers is completed, but it could be that for example the server is down or client are offline. In this case the while (true) loop is never finished and shutdownSemaphore is never released and so you can not shutdown the client.