### PR TITLE
don't run into exception when you are offline on startup

### DIFF
--- a/src/main/java/com/zaxxer/influx4j/InfluxDB.java
+++ b/src/main/java/com/zaxxer/influx4j/InfluxDB.java
@@ -31,6 +31,7 @@ import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -505,9 +506,13 @@ public class InfluxDB implements AutoCloseable {
             switch (protocol) {
                case HTTP:
                case HTTPS: {
-                  if (!validateConnection()) {
-                     throw new RuntimeException("Access denied to user '" + username + "'.");
-                  }
+                  try {
+	                  if (!validateConnection()) {
+	                     throw new RuntimeException("Access denied to user '" + username + "'.");
+	                  }
+            	  } catch (UnknownHostException uhe) {
+            		  LOGGER.log(Level.SEVERE, "Unable to create connection.  Message: " + uhe.getLocalizedMessage());
+            	  }
 
                   connection = CONNECTIONS.computeIfAbsent(
                      InfluxDB.createURL(this.baseURL,


### PR DESCRIPTION
If you start the InfluxDBManager but you are offline you run into an UnknownHostException, we catch this, give an error log but don't throw the error. In this situation when you go online later you are able to write previously collected points.
In this scenario you can go on and offline and so on without exceptions.