### PR TITLE
Don't break if validateConnection is running into IOException

### DIFF
--- a/src/main/java/com/zaxxer/influx4j/InfluxDB.java
+++ b/src/main/java/com/zaxxer/influx4j/InfluxDB.java
@@ -505,9 +505,11 @@ public class InfluxDB implements AutoCloseable {
             switch (protocol) {
                case HTTP:
                case HTTPS: {
-                  if (!validateConnection()) {
-                     throw new RuntimeException("Access denied to user '" + username + "'.");
-                  }
+                  try {
+	            	  if (!validateConnection()) {
+	            		  throw new RuntimeException("Access denied to user '" + username + "'.");
+	            	  }
+            	  } catch (final IOException e) {}
 
                   connection = CONNECTIONS.computeIfAbsent(
                      InfluxDB.createURL(this.baseURL,


### PR DESCRIPTION
If server is down or inet is not available at the moment when we build InfluxDB we run into IOException for timeout or unknown host or others. But we would like to keep the client up, if inet is coming back or server is up again, all in meantime collected points are persisted without problem.
We think this is the better solution
Perhaps we can add a default/cusomizable behavior for this